### PR TITLE
Fix inconsistent parameter names between function declarations and definitions

### DIFF
--- a/Analysis/include/QwParameterFile.h
+++ b/Analysis/include/QwParameterFile.h
@@ -187,8 +187,8 @@ class QwParameterFile {
     /// \brief Rewinds to the start and read until it finds next module header
     QwParameterFile* ReadModulePreamble();
     QwParameterFile* ReadUntilNextModule(const bool add_current_line = false);
-    QwParameterFile* ReadNextModule(std::string &secname, bool keep_header = false);
-    QwParameterFile* ReadNextModule(TString &secname, bool keep_header = false);
+    QwParameterFile* ReadNextModule(std::string &secname, const bool keep_header = false);
+    QwParameterFile* ReadNextModule(TString &secname, const bool keep_header = false);
     QwParameterFile* ReadNextModule(const bool keep_header = false) {
       std::string dummy;
       return ReadNextModule(dummy, keep_header);

--- a/Parity/include/QwBPMCavity.h
+++ b/Parity/include/QwBPMCavity.h
@@ -91,7 +91,7 @@ class QwBPMCavity : public VQwBPM {
   Bool_t  ApplySingleEventCuts();//Check for good events by stting limits on the devices readings
   //void    SetSingleEventCuts(TString ch_name, Double_t minX, Double_t maxX);
   /*! \brief Inherited from VQwDataElement to set the upper and lower limits (fULimit and fLLimit), stability % and the error flag on this channel */
-  void    SetSingleEventCuts(TString ch_name, UInt_t errorflag,Double_t min, Double_t max, Double_t stability, Double_t burplevel);
+  void    SetSingleEventCuts(TString ch_name, UInt_t errorflag,Double_t minX, Double_t maxX, Double_t stability, Double_t burplevel);
   void    SetEventCutMode(Int_t bcuts);
   void IncrementErrorCounters();
   void PrintErrorCounters() const;// report number of events failed due to HW and event cut faliure

--- a/Parity/include/QwBPMStripline.h
+++ b/Parity/include/QwBPMStripline.h
@@ -114,7 +114,7 @@ class QwBPMStripline : public VQwBPM {
   Bool_t  ApplySingleEventCuts();//Check for good events by stting limits on the devices readings
   //void    SetSingleEventCuts(TString ch_name, Double_t minX, Double_t maxX);
   /*   /\*! \brief Inherited from VQwDataElement to set the upper and lower limits (fULimit and fLLimit), stability % and the error flag on this channel *\/ */
-  void    SetSingleEventCuts(TString ch_name, UInt_t errorflag,Double_t min, Double_t max, Double_t stability, Double_t burplevel);
+  void    SetSingleEventCuts(TString ch_name, UInt_t errorflag,Double_t minX, Double_t maxX, Double_t stability, Double_t burplevel);
   //void    SetSingleEventCuts(TString ch_name, UInt_t errorflag,Double_t min, Double_t max, Double_t stability, Double_t burplevel){return;};
   void    SetEventCutMode(Int_t bcuts);
   void    IncrementErrorCounters();

--- a/Parity/include/QwLinearDiodeArray.h
+++ b/Parity/include/QwLinearDiodeArray.h
@@ -90,7 +90,7 @@ class QwLinearDiodeArray : public VQwBPM {
   Bool_t  ApplySingleEventCuts();//Check for good events by stting limits on the devices readings
   //void    SetSingleEventCuts(TString ch_name, Double_t minX, Double_t maxX);
   /*! \brief Inherited from VQwDataElement to set the upper and lower limits (fULimit and fLLimit), stability % and the error flag on this channel */
-  void    SetSingleEventCuts(TString ch_name, UInt_t errorflag,Double_t min, Double_t max, Double_t stability, Double_t burplevel);
+  void    SetSingleEventCuts(TString ch_name, UInt_t errorflag,Double_t minX, Double_t maxX, Double_t stability, Double_t burplevel);
   void    SetEventCutMode(Int_t bcuts);
   void IncrementErrorCounters();
   void PrintErrorCounters() const;// report number of events failed due to HW and event cut faliure

--- a/Parity/include/QwQPD.h
+++ b/Parity/include/QwQPD.h
@@ -91,7 +91,7 @@ class QwQPD : public VQwBPM {
   Bool_t  ApplySingleEventCuts();//Check for good events by stting limits on the devices readings
   //void    SetSingleEventCuts(TString ch_name, Double_t minX, Double_t maxX);
   /*! \brief Inherited from VQwDataElement to set the upper and lower limits (fULimit and fLLimit), stability % and the error flag on this channel */
-  void    SetSingleEventCuts(TString ch_name, UInt_t errorflag,Double_t min, Double_t max, Double_t stability, Double_t burplevel);
+  void    SetSingleEventCuts(TString ch_name, UInt_t errorflag,Double_t minX, Double_t maxX, Double_t stability, Double_t burplevel);
   void    SetEventCutMode(Int_t bcuts);
   void IncrementErrorCounters();
   void PrintErrorCounters() const;// report number of events failed due to HW and event cut faliure


### PR DESCRIPTION
This PR addresses clang-tidy warnings about parameter naming inconsistencies between function declarations in header files and their implementations in source files.

## Changes Made

- **QwParameterFile.h**: Added `const` qualifier to `keep_header` parameters in ReadNextModule method declarations to match source implementation
- **QwBPMStripline.h**: Changed parameter names from `min`/`max` to `minX`/`maxX` in SetSingleEventCuts methods to match source implementation
- **QwBPMCavity.h**: Changed parameter names from `min`/`max` to `minX`/`maxX` in SetSingleEventCuts methods to match source implementation  
- **QwQPD.h**: Changed parameter names from `min`/`max` to `minX`/`maxX` in SetSingleEventCuts methods to match source implementation
- **QwLinearDiodeArray.h**: Changed parameter names from `min`/`max` to `minX`/`maxX` in SetSingleEventCuts methods to match source implementation

## Testing

- Build was tested successfully with LCG_106 environment from CVMFS
- All parameter naming fixes maintain full backward compatibility and functionality
- No compilation errors related to the parameter changes

## Impact

These fixes resolve the clang-tidy `readability-inconsistent-declaration-parameter-name` warnings while maintaining full backward compatibility. The changes are purely cosmetic parameter name alignments with no functional impact.